### PR TITLE
"Multiplayer" Update

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -86,5 +86,8 @@
     "wasi",
     "yallist"
   ],
-  "stylua.targetReleaseVersion": "latest"
+  "stylua.targetReleaseVersion": "latest",
+  "conventionalCommits.scopes": [
+    "ore"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,6 +34,7 @@
     "headshots",
     "imthatguyhere",
     "ingame",
+    "ipairs",
     "isaacs",
     "jiti",
     "jridgewell",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,11 +4,14 @@
     "autoprefixer",
     "biomejs",
     "browserslist",
+    "cameramatrix",
+    "cfxid",
     "charinfo",
     "chownr",
     "citizenfx",
     "clsx",
     "colorizr",
+    "communityname",
     "Convar",
     "cssdb",
     "cssesc",
@@ -17,6 +20,7 @@
     "dismissable",
     "eabi",
     "emnapi",
+    "entitymatrix",
     "esbuild",
     "estree",
     "fdir",
@@ -85,7 +89,8 @@
     "vite",
     "vitejs",
     "wasi",
-    "yallist"
+    "yallist",
+    "yourtype"
   ],
   "stylua.targetReleaseVersion": "latest",
   "conventionalCommits.scopes": [

--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ A FiveM/GTA V server resource that integrates with the Medal.tv desktop client t
 
 1. Place this resource folder into your server's `resources/` directory.
 2. In your server's `server.cfg` (or whatever config file your server uses to load resources), add the line below (replace with your actual folder name for this resource):
+
     ```cfg
     ensure medal--fivem-resource
     ```
+
 3. Start (or restart) your server.
 
 ## Usage
@@ -132,7 +134,7 @@ The UI has its own Node.js project under `ui`. Use pnpm to install and build the
 
 Event configs define how an auto-clipping event appears and behaves in the UI. See `clipping/__types.lua`.
 
-```
+```lua
 EventConfig = {
   id: string,           -- unique id used internally and for persistence
   title: string,        -- display name in the UI

--- a/clipping/client-main.lua
+++ b/clipping/client-main.lua
@@ -22,6 +22,9 @@
 Medal = Medal or {}
 Medal.AC = Medal.AC or {} --//=-- The namespace for the client Auto Clipping functions
 
+--//=-- Wait Constants
+local RESOURCE_START_DELAY_MS = 100
+
 ---Safely reads a specific event config from the shared `Config` table
 ---@param eventId string
 ---@return EventConfig
@@ -98,7 +101,7 @@ AddEventHandler('onClientResourceStart', function (resourceName)
     if resourceName ~= GetCurrentResourceName() then return end
 
     CreateThread(function ()
-        Wait(100)
+        Wait(RESOURCE_START_DELAY_MS)
 
         Medal.AC.registerCommand()
         Medal.AC.buildClippingUi()

--- a/config.lua
+++ b/config.lua
@@ -52,8 +52,10 @@ Config.Screenshots = {
     ScreenshotBasicOverride = true --//=-- Override `screenshot-basic` resource exports with Medal functionality
 }
 
+
+
 --[[
-    WARNING: DO NOT MODIFY ANYTHING IN Config.GameVein
+    WARNING: DO NOT MODIFY ANYTHING IN Config.GameVein, or below this point
     This table contains critical connection settings for the GameVein integration.
     Modifying these values may break the resource functionality.
 ]]
@@ -64,11 +66,15 @@ Config.GameVein = {
         port = 12556,
         protocol = "ws",
         --//=-- Reconnect behavior (UI WebSocket client)
-        --//=-- Number of short attempts before switching to the long interval
-        reconnectShortAttempts = 5,
-        --//=-- Short retry interval (ms)
-        reconnectShortMs = 30 * S,
-        --//=-- Longer, silent retry interval (ms)
-        reconnectLongMs = 120 * S,
+        reconnectShortAttempts = 5, --//=-- Number of short attempts before switching to the long interval
+        reconnectShortMs = 30 * S, --//=-- Short retry interval (ms)
+        reconnectLongMs = 120 * S, --//=-- Longer, silent retry interval (ms)
     }
+}
+
+--//=-- Assayer defaults (used by nearby data aggregation)
+Config.Assayer = {
+    ProximityRadius = 60.0, --//=-- Default radius (meters) used when a request specifies proximity fan-out but omits radius
+    RequestTimeoutMs = 1500, --//=-- Default timeout (ms) for waiting on nearby players' responses
+    BucketMismatchLogTolerance = 5.0, --//=-- Extra tolerance (meters) used only for debug logging on bucket mismatches
 }

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -29,9 +29,9 @@ server_scripts {
   'lib/server-*.lua',
   'services/server-*.lua',
   'gameVein/server-*.lua',
+  'gameVein/assayer/server-*.lua',
   'gameVein/ore/server-*.lua',
   'superSoaker/server-*.lua',
-  'lib/server-*.lua',
 }
 
 files {

--- a/gameVein/README.md
+++ b/gameVein/README.md
@@ -4,15 +4,14 @@ GameVein is the in-resource data pipeline that extracts (mines) small, typed chu
 
 - __ore/__
   - Functions that return specific pieces of data (ex: `name`, `cfxId`, `job`, `vehicle`).
-- __assayer/__
-  - Routing helpers only. 
-    - Maps ore type strings to the correct `Medal.GV.Ore.*()` producer.
+- __assayer__/
+  - Routing helpers only.
+    - Maps ore type strings via a lowercase-keyed dispatch table (case-insensitive) to the correct `Medal.GV.Ore.*()` producer.
     - Framework detection has moved to `services/`.
 - __shaft/__
   - Transport helpers. Opens/closes the UI WebSocket, and sends the resulting envelopes ("minecarts").
 - `client-main.lua`
   - Reads the WebSocket config from `Config.GameVein.*` and asks the UI to connect via NUI `ws:connect`.
-  - Supports optional reconnect intervals (forwarded to the UI):
     - `Config.GameVein.WebSocket.reconnectShortMs` – the first retry delay after disconnect (default 30000ms)
     - `Config.GameVein.WebSocket.reconnectLongMs` – the subsequent silent retry delay (default 120000ms)
     - `Config.GameVein.WebSocket.reconnectShortAttempts` – the number of short retries before switching to long interval (default 5)
@@ -29,7 +28,7 @@ GameVein is the in-resource data pipeline that extracts (mines) small, typed chu
 
 ## Adding a New Ore type (quick start)
 
-1) __Create a new function__ in `gameVein/ore/` that returns the ore payload.
+1) __Create a new function__ in `gameVein/ore/` that returns the ore payload:
 
 ```lua
 --//=-- gameVein/ore/client-job.lua
@@ -45,13 +44,11 @@ function Medal.GV.Ore.job()
 end
 ```
 
-2) __Route the ore type__ in `gameVein/assayer/client-assayer.lua` by extending `Medal.GV.Ore.assay()`.
+2) __Route the ore type__ in `gameVein/assayer/client-assayer.lua` by adding an entry to the lowercase-keyed dispatch (keys must be lowercase; `type` preserves canonical casing):
 
 ```lua
---//=-- Inside Medal.GV.Ore.assay(req)
-if oreType == 'job' then
-  return Medal.GV.Ore.job()
-end
+--//=-- Inside Medal.GV.Ore.assay(req), after _oreDispatch is initialized
+_oreDispatch.job = { type = 'job', fn = Medal.GV.Ore.job }
 ```
 
 3) __If server data is required__, use the shared Request helpers.

--- a/gameVein/assayer/README.md
+++ b/gameVein/assayer/README.md
@@ -24,25 +24,17 @@ See `lib/shared-request.lua`:
 
 ## Extending Ore Routing
 
-To add a new ore type, include another branch in `Medal.GV.Ore.assay()`:
+The assayer now uses a lowercase-keyed dispatch table (case-insensitive lookup). To add a new ore type, add an entry to the dispatch after it is initialized. Keys must be lowercase; the `type` value should preserve the canonical casing, and `fn` should point to the ore function.
 
 ```lua
 --//=-- gameVein/assayer/client-assayer.lua
-if oreType == 'yourType' then
-  return Medal.GV.Ore.yourType()
-end
+-- After _oreDispatch is initialized inside Medal.GV.Ore.assay(req):
+_oreDispatch.yourtype = { type = 'yourType', fn = Medal.GV.Ore.yourType }
 
---//=-- For bundled requests
-if oreType == 'bundle' and type(req.types) == 'table' then
-  local results = {}
-  for _, subType in ipairs(req.types) do
-    local result = Medal.GV.Ore.assay(subType)
-    if result ~= nil then
-      results[subType] = result
-    end
-  end
-  return results
-end
+-- Lookup is case-insensitive:
+-- local key = string.lower(oreType)
+-- local entry = _oreDispatch[key]
+-- if entry then return entry.fn() end
 ```
 
 ## How It's Interacted With
@@ -98,4 +90,5 @@ print('player name', name)
 ```
 
 Notes:
+
 - `Medal.GV.Ore.assay(req)` accepts a string (the type), or a table (also the type, and not for eating) with `type = string`.

--- a/gameVein/assayer/client-assayer.lua
+++ b/gameVein/assayer/client-assayer.lua
@@ -14,22 +14,64 @@
     - Medal.GV.Ore.assay : Assay a requested ore, returning it
 ]]
 
-  
 
 Medal = Medal or {}
 Medal.GV = Medal.GV or {}
 Medal.GV.Ore = Medal.GV.Ore or {}
 --//=-- Client-side Assayer routes ore requests only (framework detection moved to services)
 Medal.GV.Assayer = Medal.GV.Assayer or {}
+
+--//=-- Pending table for nearby ore aggregation responses
+local _pendingNearby = {}
+
 --//=-- Lazy-initialized, lowercase-keyed dispatch for ore types
 --//=-- Each value holds the canonical `type` casing and its function
 local _oreDispatch = nil
+
+--//=-- Receive aggregated results from the server for a nearby request
+RegisterNetEvent('medal:gv:assayer:resNearby', function(requestId, others, invokerBucket)
+  _pendingNearby[requestId] = { others = others or {}, invokerBucket = invokerBucket or 0 }
+  --//=-- Debug: record receipt of aggregated nearby results
+  if Logger and Logger.debug then
+    local count = 0
+    if type(others) == 'table' then count = #others end
+    Logger.debug('assayer:client:resNearby', { requestId = requestId, count = count, invokerBucket = invokerBucket or 0 })
+  end
+end)
+
+--//=-- Server asks this client to assay an ore (or bundle) on behalf of a nearby requester
+RegisterNetEvent('medal:gv:assayer:reqFromServer', function(invokerId, requestId, payload)
+  local data = nil
+  if Logger and Logger.debug then
+    Logger.debug('assayer:client:reqFromServer', { from = invokerId, requestId = requestId, payload = payload })
+  end
+
+  if type(payload) == 'table' and type(payload.types) == 'table' then
+    local results = {}
+    for _, subType in pairs(payload.types) do
+      local r = Medal.GV.Ore.assay(subType)
+      if r ~= nil then results[subType] = r end
+    end
+    data = results
+  elseif type(payload) == 'table' and type(payload.ore) == 'string' then
+    data = Medal.GV.Ore.assay(payload.ore)
+  end
+
+  --//=-- Respond back to server with our result (may be nil if unknown)
+  if Logger and Logger.debug then
+    local hasData = data ~= nil
+    Logger.debug('assayer:client:resToServer', { requestId = requestId, to = invokerId, hasData = hasData })
+  end
+  TriggerServerEvent('medal:gv:assayer:resFromClient', requestId, invokerId, data)
+end)
 
 --- Assay a requested ore, and return the relevant data
 --- Accepted forms:
 ---  - string: Treated as the `type` (e.g., 'name')
 ---  - table: { type = 'name', ... }
 ---  - table: { type = 'bundle', types = { 'name', 'job' } }
+---  - table: { type = 'job', radius = 60, maxPlayers = 5 }   --//=-- proximity fan-out for a single ore
+---  - table: { type = 'bundle', types = { 'name', 'job' }, radius = 60, maxPlayers = 5 } --//=-- proximity fan-out for a bundle
 --- @param req string|table
 --- @return any|table|nil The data for the requested ore, a table of results for a bundle, or nil if unknown
 function Medal.GV.Ore.assay(req)
@@ -39,6 +81,66 @@ function Medal.GV.Ore.assay(req)
     oreType = req
   elseif type(req) == 'table' and type(req.type) == 'string' then
     oreType = req.type
+  end
+
+  --//=-- Proximity fan-out must run BEFORE direct returns for single ores
+  --//=-- If a request includes `radius`, gather from nearby players too (OneSync Infinity)
+  if type(req) == 'table' and ((tonumber(req.radius or 0) or 0) > 0) then
+    local radius = tonumber(req.radius or 60) or 60
+    local isBundle = (oreType == 'bundle') or (type(req.types) == 'table')
+    local maxPlayers = tonumber(req.max or req.maxPlayers or req.count or 0) or 0
+
+    --//=-- Build the invoking player's data (first entry of return value)
+    local selfData = nil
+    if isBundle then
+      local results = {}
+      for _, subType in pairs(req.types) do
+        local r = Medal.GV.Ore.assay(subType)
+        if r ~= nil then results[subType] = r end
+      end
+      selfData = results
+    else
+      local targetType = oreType
+      if type(targetType) ~= 'string' then
+        return { nil, {} }
+      end
+      selfData = Medal.GV.Ore.assay(targetType)
+    end
+
+    --//=-- Ask server to gather from nearby players
+    local requestId = Medal.GV.Request.buildId()
+    if Logger and Logger.debug then
+      Logger.debug('assayer:client:reqNearby', { requestId = requestId, oreType = oreType, radius = radius, isBundle = isBundle, max = maxPlayers, types = isBundle and req.types or nil })
+    end
+    TriggerServerEvent('medal:gv:assayer:reqNearby', requestId, {
+      radius = radius,
+      types = isBundle and req.types or nil,
+      ore = (not isBundle) and oreType or nil,
+      timeoutMs = tonumber(req.timeoutMs or 1500) or 1500,
+      max = maxPlayers,
+    })
+
+    --//=-- Await aggregated nearby array of { id, source, name, bucket, data, primary=false }
+    local pack = Medal.GV.Request.await(_pendingNearby, requestId, req.timeoutMs, { others = {}, invokerBucket = 0 })
+    local others = (type(pack) == 'table' and type(pack.others) == 'table') and pack.others or {}
+    local invBucket = (type(pack) == 'table' and tonumber(pack.invokerBucket or 0)) or 0
+    if Logger and Logger.debug then
+      local count = #others
+      Logger.debug('assayer:client:awaitNearby:done', { requestId = requestId, count = count, invokerBucket = invBucket })
+    end
+    --//=-- Multi-request (radius): Always return primary wrapper to match others
+    local invPid = PlayerId()
+    local invSrc = GetPlayerServerId(invPid)
+    local invName = GetPlayerName(invPid) or 'unknown'
+    local primary = {
+      id = invSrc,
+      source = tostring(invSrc),
+      name = invName,
+      data = selfData,
+      primary = true,
+      bucket = invBucket,
+    }
+    return { primary, others }
   end
 
   --//=-- Initialize the dispatch table on first use to avoid early binding
@@ -63,9 +165,8 @@ function Medal.GV.Ore.assay(req)
       return entry.fn()
     end
   end
-  end
 
-    --//=-- Handle bundle requests, which assay multiple ore types at once
+  --//=-- Handle bundle requests, which assay multiple ore types at once
   if oreType == 'bundle' and type(req.types) == 'table' then
     local results = {}
     for _, subType in pairs(req.types) do

--- a/gameVein/assayer/server-assayer.lua
+++ b/gameVein/assayer/server-assayer.lua
@@ -1,0 +1,227 @@
+--[[
+  Medal.tv - FiveM Resource
+  =========================
+  File: gameVein/assayer/server-assayer.lua
+  =====================
+  Description:
+    Server coordinator for nearby ore requests. Aggregates data from nearby players (OneSync Infinity compatible).
+  ---
+  Exports:
+    None
+  ---
+  Globals:
+    None
+]]
+
+print('Medal [assayer] server loaded')
+
+--//=-- Pending aggregation state keyed by requestId
+local PendingNearby = {}
+
+--//=-- Safe distance calculation between two coords
+---@class vector3
+---@class vector4
+---@alias CoordLike vector3|vector4|{ x: number, y: number, z: number, w?: number }|number[]
+
+--- Normalize a coord-like value into a vector3, or nil if invalid
+--- @param c CoordLike
+--- @return vector3|nil
+local function normalizeCoord(c)
+  if not c then return nil end
+  local t = type(c)
+  if t == 'vector3' then return c end
+  if t == 'vector4' then return vector3(c.x, c.y, c.z) end
+  if t == 'table' then
+    local x = (c.x or c[1])
+    local y = (c.y or c[2])
+    local z = (c.z or c[3])
+    if x ~= nil and y ~= nil and z ~= nil then
+      return vector3(tonumber(x) or 0.0, tonumber(y) or 0.0, tonumber(z) or 0.0)
+    end
+  end
+  return nil
+end
+
+--- Compute Euclidean distance using vector length (#(a-b)). Returns a large number when invalid.
+--- Extra arguments are ignored (backward compatible with prior callers).
+--- @param a CoordLike
+--- @param b CoordLike
+--- @return number
+local function distance(a, b, _)
+  local va = normalizeCoord(a)
+  local vb = normalizeCoord(b)
+  if not va or not vb then return 1e9 end
+  return #(va - vb)
+end
+
+--//=-- Finalize and respond to invoker if not already sent
+local function finalizeNearby(requestId)
+  local st = PendingNearby[requestId]
+  if not st or st.sent then return end
+  st.sent = true
+  --//=-- Send list of nearby players' data back to invoker
+  if Logger and Logger.debug then
+    Logger.debug('assayer:server:finalizeNearby', { invoker = st.invoker, requestId = requestId, total = #(st.results or {}) })
+  end
+  TriggerClientEvent('medal:gv:assayer:resNearby', st.invoker, requestId, st.results, st.invokerBucket or 0)
+  PendingNearby[requestId] = nil
+end
+
+--//=-- Receive ore data from a client we queried
+RegisterNetEvent('medal:gv:assayer:resFromClient', function(requestId, invokerId, data)
+  local src = source
+  local st = PendingNearby[requestId]
+  if not st or st.invoker ~= invokerId or st.sent then return end
+
+  if data ~= nil then
+    local bucket = (GetPlayerRoutingBucket and GetPlayerRoutingBucket(tostring(src))) or 0
+    table.insert(st.results, {
+      id = src,
+      source = tostring(src),
+      name = GetPlayerName(src) or 'unknown',
+      data = data,
+      primary = false,
+      bucket = bucket,
+    })
+  end
+  if Logger and Logger.debug then
+    Logger.debug('assayer:server:resFromClient', { requestId = requestId, from = src, hasData = data ~= nil, responded = (st.responded or 0) + 1, expected = st.expected })
+  end
+  st.responded = st.responded + 1
+  if st.responded >= st.expected then
+    finalizeNearby(requestId)
+  end
+end)
+
+--//=-- Entry point: invoker requests ores from nearby players
+RegisterNetEvent('medal:gv:assayer:reqNearby', function(requestId, payload)
+  local src = source
+  local radius = tonumber(payload and payload.radius or 60.0) or 60.0
+  local timeoutMs = tonumber(payload and payload.timeoutMs or 1500) or 1500
+  local maxCount = tonumber(payload and (payload.max or payload.maxPlayers or payload.count) or 0) or 0
+  local isBundle = type(payload) == 'table' and type(payload.types) == 'table'
+  local ore = (not isBundle) and (payload and payload.ore) or nil
+
+  if Logger and Logger.debug then
+    Logger.debug('assayer:server:reqNearby:entry', { invoker = src, requestId = requestId, payload = payload })
+  end
+
+  --//=-- Normalize payload we forward to other clients (strip 'nearby')
+  local forwardPayload = isBundle and { types = payload.types } or (ore and { ore = ore } or nil)
+
+  --//=-- Validate forward payload
+  if not forwardPayload then
+    TriggerClientEvent('medal:gv:assayer:resNearby', src, requestId, {}, 0)
+    return
+  end
+
+  if Logger and Logger.debug then
+    Logger.debug('assayer:server:reqNearby', { invoker = src, requestId = requestId, radius = radius, max = maxCount, isBundle = isBundle, ore = ore, forward = forwardPayload })
+  end
+
+  --//=-- Try to get invoker ped and coords (OneSync required)
+  local invokerPed = GetPlayerPed(src)
+  if not invokerPed or invokerPed <= 0 then
+    TriggerClientEvent('medal:gv:assayer:resNearby', src, requestId, {})
+    return
+  end
+  local invokerCoords = GetEntityCoords(invokerPed)
+  local invokerBucket = (GetPlayerRoutingBucket and GetPlayerRoutingBucket(tostring(src))) or 0
+  if Logger and Logger.debug then
+    Logger.debug('assayer:server:invokerBucket', { invoker = src, bucket = invokerBucket })
+  end
+
+  --//=-- Build candidate list based on same routing bucket and within radius, with distances
+  local candidates = {}
+  local players = GetPlayers()
+  for _, sid in ipairs(players) do
+    local pid = tonumber(sid) or -1
+    if pid ~= src then
+      local bucket = (GetPlayerRoutingBucket and GetPlayerRoutingBucket(tostring(sid))) or 0
+      if bucket == invokerBucket then
+        local ped = GetPlayerPed(pid)
+        if ped and ped > 0 then
+          local coords = GetEntityCoords(ped)
+          local dist = distance(invokerCoords, coords, false)
+          if dist <= radius then
+            candidates[#candidates+1] = { pid = pid, dist = dist }
+          end
+        end
+      else
+        if Logger and Logger.debug then
+          local ped = GetPlayerPed(pid)
+          if ped and ped > 0 then
+            local coords = GetEntityCoords(ped)
+            local dist = distance(invokerCoords, coords, false)
+            if dist <= (radius + 5.0) then
+              Logger.debug('assayer:server:skipBucketMismatch', { pid = pid, pidBucket = bucket, invokerBucket = invokerBucket, dist = dist })
+            end
+          end
+        end
+      end
+    end
+  end
+
+  --//=-- Fallback: if no candidates matched bucket, retry ignoring bucket filter
+  if #candidates == 0 then
+    if Logger and Logger.debug then
+      Logger.debug('assayer:server:retryNoBucket', { invoker = src, invokerBucket = invokerBucket, radius = radius })
+    end
+    for _, sid in ipairs(players) do
+      local pid = tonumber(sid) or -1
+      if pid ~= src then
+        local ped = GetPlayerPed(pid)
+        if ped and ped > 0 then
+          local coords = GetEntityCoords(ped)
+          local dist = distance(invokerCoords, coords, false)
+          if dist <= radius then
+            candidates[#candidates+1] = { pid = pid, dist = dist }
+          end
+        end
+      end
+    end
+  end
+
+  if Logger and Logger.debug then
+    Logger.debug('assayer:server:candidates', { invoker = src, count = #candidates })
+  end
+
+  --//=-- Sort by nearest first
+  table.sort(candidates, function(a, b) return (a.dist or 1e9) < (b.dist or 1e9) end)
+
+  --//=-- Apply max limit if provided
+  local targets = {}
+  local limit = (maxCount and maxCount > 0) and math.min(maxCount, #candidates) or #candidates
+  for i = 1, limit do
+    targets[#targets+1] = candidates[i].pid
+  end
+
+  if Logger and Logger.debug then
+    Logger.debug('assayer:server:targets', { invoker = src, expected = #targets, targets = targets })
+  end
+
+  if #targets == 0 then
+    TriggerClientEvent('medal:gv:assayer:resNearby', src, requestId, {}, invokerBucket or 0)
+    return
+  end
+
+  --//=-- Initialize pending state
+  PendingNearby[requestId] = {
+    invoker = src,
+    expected = #targets,
+    responded = 0,
+    results = {},
+    sent = false,
+    invokerBucket = invokerBucket,
+  }
+
+  --//=-- Ask each nearby client to assay and respond
+  for _, pid in ipairs(targets) do
+    TriggerClientEvent('medal:gv:assayer:reqFromServer', pid, src, requestId, forwardPayload)
+  end
+
+  --//=-- Timeout to finalize if not all responses
+  SetTimeout(timeoutMs, function()
+    finalizeNearby(requestId)
+  end)
+end)

--- a/gameVein/assayer/server-assayer.lua
+++ b/gameVein/assayer/server-assayer.lua
@@ -15,6 +15,11 @@
 
 print('Medal [assayer] server loaded')
 
+--//=-- Assayer defaults (override via Config.Assayer if present)
+local ASSAYER_DEFAULT_RADIUS = (Config and Config.Assayer and tonumber(Config.Assayer.ProximityRadius)) or 60.0
+local ASSAYER_DEFAULT_TIMEOUT_MS = (Config and Config.Assayer and tonumber(Config.Assayer.RequestTimeoutMs)) or 1500
+local ASSAYER_BUCKET_MISMATCH_LOG_TOLERANCE = (Config and Config.Assayer and tonumber(Config.Assayer.BucketMismatchLogTolerance)) or 5.0
+
 --//=-- Pending aggregation state keyed by requestId
 local PendingNearby = {}
 
@@ -96,8 +101,8 @@ end)
 --//=-- Entry point: invoker requests ores from nearby players
 RegisterNetEvent('medal:gv:assayer:reqNearby', function(requestId, payload)
   local src = source
-  local radius = tonumber(payload and payload.radius or 60.0) or 60.0
-  local timeoutMs = tonumber(payload and payload.timeoutMs or 1500) or 1500
+  local radius = tonumber(payload and payload.radius or ASSAYER_DEFAULT_RADIUS) or ASSAYER_DEFAULT_RADIUS
+  local timeoutMs = tonumber(payload and payload.timeoutMs or ASSAYER_DEFAULT_TIMEOUT_MS) or ASSAYER_DEFAULT_TIMEOUT_MS
   local maxCount = tonumber(payload and (payload.max or payload.maxPlayers or payload.count) or 0) or 0
   local isBundle = type(payload) == 'table' and type(payload.types) == 'table'
   local ore = (not isBundle) and (payload and payload.ore) or nil
@@ -153,7 +158,7 @@ RegisterNetEvent('medal:gv:assayer:reqNearby', function(requestId, payload)
           if ped and ped > 0 then
             local coords = GetEntityCoords(ped)
             local dist = distance(invokerCoords, coords, false)
-            if dist <= (radius + 5.0) then
+            if dist <= (radius + ASSAYER_BUCKET_MISMATCH_LOG_TOLERANCE) then
               Logger.debug('assayer:server:skipBucketMismatch', { pid = pid, pidBucket = bucket, invokerBucket = invokerBucket, dist = dist })
             end
           end

--- a/gameVein/ore/README.md
+++ b/gameVein/ore/README.md
@@ -29,31 +29,26 @@ See implementations in this folder for reference:
 
 ## How Ore Routing/Assaying Works
 
-The router in `gameVein/assayer/client-assayer.lua` inspects the request and calls the matching producer:
+The router in `gameVein/assayer/client-assayer.lua` now uses a lowercase-keyed dispatch table for case-insensitive routing. Keys are lowercase; each entry preserves the canonical `type` casing and points to the producer function.
 
 ```lua
 --//=-- Inside Medal.GV.Ore.assay(req)
-if oreType == 'name' then
-  return Medal.GV.Ore.name()
-end
-if oreType == 'cfxId' then
-  return Medal.GV.Ore.cfxId()
-end
-if oreType == 'heartbeat' then
-  return Medal.GV.Ore.heartbeat()
-end
-if oreType == 'job' then
-  return Medal.GV.Ore.job()
-end
-if oreType == 'entityMatrix' then
-  return Medal.GV.Ore.entityMatrix()
-end
-if oreType == 'cameraMatrix' then
-  return Medal.GV.Ore.cameraMatrix()
-end
+-- Initialized once, then used for lookups
+_oreDispatch = {
+  name = { type = 'name', fn = Medal.GV.Ore.name },
+  cfxid = { type = 'cfxId', fn = Medal.GV.Ore.cfxId },
+  heartbeat = { type = 'heartbeat', fn = Medal.GV.Ore.heartbeat },
+  job = { type = 'job', fn = Medal.GV.Ore.job },
+  entitymatrix = { type = 'entityMatrix', fn = Medal.GV.Ore.entityMatrix },
+  cameramatrix = { type = 'cameraMatrix', fn = Medal.GV.Ore.cameraMatrix },
+  vehicle = { type = 'vehicle', fn = Medal.GV.Ore.vehicle },
+}
 
-if oreType == 'vehicle' then
-  return Medal.GV.Ore.vehicle()
+-- Case-insensitive lookup
+local key = (type(oreType) == 'string') and string.lower(oreType) or nil
+local entry = key and _oreDispatch[key] or nil
+if entry and type(entry.fn) == 'function' then
+  return entry.fn()
 end
 ```
 
@@ -75,13 +70,11 @@ function Medal.GV.Ore.job()
 end
 ```
 
-2) __Route it__ in `gameVein/assayer/client-assayer.lua`:
+2) __Route it__ in `gameVein/assayer/client-assayer.lua` by adding an entry to the lowercase-keyed dispatch (keys must be lowercase; `type` preserves canonical casing):
 
 ```lua
---//=-- Inside Medal.GV.Ore.assay(req)
-if oreType == 'job' then
-  return Medal.GV.Ore.job()
-end
+--//=-- Inside Medal.GV.Ore.assay(req), after _oreDispatch is initialized
+_oreDispatch.job = { type = 'job', fn = Medal.GV.Ore.job }
 ```
 
 3) __If server data is required__, use the shared Request helpers from `lib/shared-request.lua`.

--- a/gameVein/ore/README.md
+++ b/gameVein/ore/README.md
@@ -15,6 +15,7 @@ to communicate with the server.
 - __vehicle__ — `Medal.GV.Ore.vehicle()` returns `{ inVehicle, vehicleInfo }` where `inVehicle` is a boolean indicating if the player is in a vehicle, and `vehicleInfo` is `{ id, name, hash, class, className }` for the current (or last driven) vehicle (client).
 
 See implementations in this folder for reference:
+
 - `client-name.lua`
 - `server-name.lua`
 - `client-cfx-id.lua`

--- a/lib/shared-request.lua
+++ b/lib/shared-request.lua
@@ -18,6 +18,9 @@ Medal = Medal or {}
 Medal.GV = Medal.GV or {}
 Medal.GV.Request = Medal.GV.Request or {}
 
+--//=-- Default timeout for request/response operations (ms)
+local REQUEST_DEFAULT_TIMEOUT_MS = 5000
+
 --- Build a unique (enough) request id for the local player
 --- Format: "<playerId>:<gameTimer>"
 --- @return string requestId
@@ -30,11 +33,11 @@ end
 --- Cleans up the pending entry on success or timeout
 --- @param pending table   --//=-- Table of in-flight results, keyed by requestId
 --- @param requestId string
---- @param timeoutMs? integer  --//=-- Defaults to 5000
+--- @param timeoutMs? integer  --//=-- Defaults to REQUEST_DEFAULT_TIMEOUT_MS
 --- @param defaultValue any    --//=-- Value to return on timeout
 --- @return any result
 function Medal.GV.Request.await(pending, requestId, timeoutMs, defaultValue)
-  local deadline = GetGameTimer() + (timeoutMs or 5000)
+  local deadline = GetGameTimer() + (timeoutMs or REQUEST_DEFAULT_TIMEOUT_MS)
   while GetGameTimer() < deadline do
     local v = pending[requestId]
     if v ~= nil then

--- a/services/README.md
+++ b/services/README.md
@@ -28,7 +28,7 @@ Detects which gameplay framework the server is running and exposes small helpers
 
 `FrameworkKey` is defined in `gameVein/__types.lua` and is one of:
 
-```
+```lua
 'esx' | 'qbx' | 'qb' | 'nd' | 'ox' | 'tmc' | 'unknown'
 ```
 
@@ -36,7 +36,7 @@ Detects which gameplay framework the server is running and exposes small helpers
 
 The server checks for known resources in this order (first match wins, QBX first as it provides the same as QB):
 
-```
+```md
 ESX -> QBX -> QB -> ND -> OX -> TMC -> unknown
 ```
 

--- a/services/client-framework-detection.lua
+++ b/services/client-framework-detection.lua
@@ -23,6 +23,10 @@ Medal.Services = Medal.Services or {}
 ---@field getKey fun(timeoutMs?: integer): FrameworkKey
 Medal.Services.Framework = Medal.Services.Framework or {}
 
+--//=-- Wait and Timeout constants
+local FRAMEWORK_REQUEST_TIMEOUT_MS = 5000
+local WAIT_INSTANT = 0
+
 --//=-- In-flight results, keyed by request id
 local pendingResults = {}
 
@@ -57,7 +61,7 @@ RegisterNetEvent('medal:services:framework:resKey', function(reqId, key)
 end)
 
 --- Request the server framework key and wait for a response
---- @param timeoutMs? integer Optional timeout in milliseconds (default 5000)
+--- @param timeoutMs? integer Optional timeout in milliseconds (default FRAMEWORK_REQUEST_TIMEOUT_MS)
 --- @return FrameworkKey key The detected framework key, or 'unknown' on timeout
 function Medal.Services.Framework.getKey(timeoutMs)
   --//=-- Return cached non-unknown immediately
@@ -74,15 +78,15 @@ function Medal.Services.Framework.getKey(timeoutMs)
   --//=-- Await response with timeout, using shared request helper when available
   local key = nil
   if Medal and Medal.GV and Medal.GV.Request and Medal.GV.Request.await then
-    key = Medal.GV.Request.await(pendingResults, reqId, timeoutMs or 5000, 'unknown')
+    key = Medal.GV.Request.await(pendingResults, reqId, timeoutMs or FRAMEWORK_REQUEST_TIMEOUT_MS, 'unknown')
   else
     --//=-- Fallback simple await if shared helper not present
     local started = GetGameTimer()
-    local timeout = (timeoutMs or 5000)
+    local timeout = (timeoutMs or FRAMEWORK_REQUEST_TIMEOUT_MS)
     while (GetGameTimer() - started) < timeout do
       local val = pendingResults[reqId]
       if val ~= nil then key = val; break end
-      Wait(0)
+      Wait(WAIT_INSTANT)
     end
     key = key or 'unknown'
   end

--- a/superSoaker/README.md
+++ b/superSoaker/README.md
@@ -14,6 +14,9 @@ Screenshot capture and upload system that provides drop-in replacement for `scre
   - Handles capture requests via `window.postMessage` and returns Data URIs or upload responses.
 
 ## How it works
+
+1. **Client** (`superSoaker/client-main.lua`)
+   - Exposes exports to capture locally or upload.
    - Listens for server requests to capture.
    - Uses a simple correlation map so async NUI replies route to the right callback.
 
@@ -33,14 +36,14 @@ The `fxmanifest.lua` wires the built UI (`ui_page 'ui/dist/index.html'`). The cl
 
 File: `superSoaker/client-main.lua`
 
-- __fillSoaker(options?: SoakerOptions, cb: fun(data: string))__
+- **fillSoaker(options?: SoakerOptions, cb: fun(data: string))**
   - Captures a screenshot and returns a `data:image/...;base64,...` URI to your callback.
   - Options:
     - `encoding`: 'jpg' | 'png' | 'webp' (default: 'jpg')
     - `quality`: number 0..1 (for jpg/webp, default 0.92)
     - `headers`: table<string,string> (only used for upload paths)
 
-- __shootWater(url: string, field: string, options?: SoakerOptions, cb: fun(result: string))__
+- **shootWater(url: string, field: string, options?: SoakerOptions, cb: fun(result: string))**
   - Captures a screenshot and uploads it as `multipart/form-data` to `url` with file field name `field`.
   - Returns the HTTP response text from the upload endpoint.
   - `headers` (optional) will be sent on the upload request.
@@ -65,7 +68,7 @@ end)
 
 File: `superSoaker/server-main.lua`
 
-- __requestPlayerWater(player: number, options: SoakerOptions, cb: fun(err:any|false, data:string, src:number))__
+- **requestPlayerWater(player: number, options: SoakerOptions, cb: fun(err:any|false, data:string, src:number))**
   - Asks `player` to capture a screenshot.
   - Calls back with `err=false` and `data` containing the Data URI returned by the client.
   - If you want the image uploaded, have the client use `shootWater` directly instead.

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,6 +1,6 @@
 # UI
 
-React + Vite frontend for the Medal FiveM resource. 
+React + Vite frontend for the Medal FiveM resource.
 It communicates with the LUA side, via NUI callbacks, and a WebSocket bridge.
 
 ## Scripts

--- a/ui/package.json
+++ b/ui/package.json
@@ -40,5 +40,5 @@
     "typescript": "~5.8.3",
     "vite": "^7.1.5"
   },
-  "packageManager": "pnpm@10.17.0"
+  "packageManager": "pnpm@10.18.0"
 }

--- a/ui/src/handlers/README.md
+++ b/ui/src/handlers/README.md
@@ -13,7 +13,7 @@ NUI event handlers that bridge UI actions with the LUA side, and the WebSocket c
     - Logs messages without a `type` property to console for debugging
   - Guards logging during the cleanup, to avoid logging post-unmount, when unavailable.
 
-From the UI code, you can also call Lua NUI callbacks directly via `fetchNui` (see `ui/src/lib/nui.ts`). 
+From the UI code, you can also call Lua NUI callbacks directly via `fetchNui` (see `ui/src/lib/nui.ts`).
 
 EX: Requesting a minecart full of ore:
 


### PR DESCRIPTION
This adds `radius` as a WebSocket JSON field when requesting data, as well as `maxPlayers`, for the distance from the player to check, and how many max to request.

The data is requested via the server after grabbing the primary user's ores, then to the server, requesting those around.

All are returned in an array, with a `data` of their own, with one or each requested ore, as well as their FiveM name, Source/ID, bucket, and a boolean to show if they were the primary user.

This probably deserves a minor version bump.